### PR TITLE
Migrated to Manifest V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name" : "__MSG_title__",
   "version": "0.1.6",
   "description": "__MSG_description__",
   "default_locale": "en",
 
-  "browser_action": {
+  "action": {
     "default_popup": "index.html",
     "default_icon": "icons/suite_38.png"
   },


### PR DESCRIPTION
I found this extension by accident. Many users can no longer use this because Manifest V2 no longer supports
I know the repository has not been updated in a long time. So I hesitated to open a pull request, but I’ve prepared a migration to Manifest V3 so the community can keep using the extension.